### PR TITLE
Get rid of dependency on environment variables in public configuration

### DIFF
--- a/config-vault/src/main/java/io/scalecube/config/vault/EnvironmentVaultTokenSupplier.java
+++ b/config-vault/src/main/java/io/scalecube/config/vault/EnvironmentVaultTokenSupplier.java
@@ -1,12 +1,11 @@
 package io.scalecube.config.vault;
 
-import com.bettercloud.vault.EnvironmentLoader;
 import com.bettercloud.vault.VaultConfig;
 import java.util.Objects;
 
 public class EnvironmentVaultTokenSupplier implements VaultTokenSupplier {
 
-  public String getToken(EnvironmentLoader environmentLoader, VaultConfig config) {
+  public String getToken(VaultConfig config) {
     return Objects.requireNonNull(config.getToken(), "vault token");
   }
 }

--- a/config-vault/src/main/java/io/scalecube/config/vault/VaultConfigSource.java
+++ b/config-vault/src/main/java/io/scalecube/config/vault/VaultConfigSource.java
@@ -32,6 +32,8 @@ public class VaultConfigSource implements ConfigSource {
 
   private static final EnvironmentLoader ENVIRONMENT_LOADER = new EnvironmentLoader();
 
+  private static final String PATHS_SEPARATOR = ":";
+
   private final VaultInvoker vault;
   private final List<String> secretsPaths;
 
@@ -73,13 +75,17 @@ public class VaultConfigSource implements ConfigSource {
     private List<String> secretsPaths =
         Optional.ofNullable(ENVIRONMENT_LOADER.loadVariable("VAULT_SECRETS_PATH"))
             .or(() -> Optional.ofNullable(ENVIRONMENT_LOADER.loadVariable("VAULT_SECRETS_PATHS")))
-            .map(s -> s.split(":"))
+            .map(s -> s.split(PATHS_SEPARATOR))
             .map(Arrays::asList)
             .orElseGet(ArrayList::new);
 
     private Builder() {}
 
     /**
+     * Appends {@code secretsPath} to {@code secretsPaths}.
+     *
+     * @param secretsPath secretsPath (may contain value with paths separated by {@code :})
+     * @return this builder
      * @deprecated will be removed in future releases without notice, use {@link
      *     #addSecretsPath(String...)} or {@link #secretsPaths(Collection)}.
      */
@@ -89,11 +95,25 @@ public class VaultConfigSource implements ConfigSource {
       return this;
     }
 
+    /**
+     * Appends one or several secretsPath\es to {@code secretsPaths}.
+     *
+     * @param secretsPath one or several secretsPath\es (each value may contain paths separated by
+     *     {@code :})
+     * @return this builder
+     */
     public Builder addSecretsPath(String... secretsPath) {
       this.secretsPaths.addAll(toSecretsPaths(Arrays.asList(secretsPath)));
       return this;
     }
 
+    /**
+     * Setter for {@code secretsPaths}.
+     *
+     * @param secretsPaths collection of secretsPath\es (each value may contain paths separated by
+     *     {@code :})
+     * @return this builder
+     */
     public Builder secretsPaths(Collection<String> secretsPaths) {
       this.secretsPaths = toSecretsPaths(secretsPaths);
       return this;
@@ -101,7 +121,7 @@ public class VaultConfigSource implements ConfigSource {
 
     private static List<String> toSecretsPaths(Collection<String> secretsPaths) {
       return secretsPaths.stream()
-          .flatMap(s -> Arrays.stream(s.split(":")))
+          .flatMap(s -> Arrays.stream(s.split(PATHS_SEPARATOR)))
           .distinct()
           .collect(Collectors.toList());
     }

--- a/config-vault/src/main/java/io/scalecube/config/vault/VaultConfigSource.java
+++ b/config-vault/src/main/java/io/scalecube/config/vault/VaultConfigSource.java
@@ -9,10 +9,12 @@ import io.scalecube.config.source.ConfigSource;
 import io.scalecube.config.source.LoadedConfigProperty;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -28,80 +30,80 @@ public class VaultConfigSource implements ConfigSource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VaultConfigSource.class);
 
-  private static final String VAULT_SECRETS_PATH = "VAULT_SECRETS_PATH";
+  private static final EnvironmentLoader ENVIRONMENT_LOADER = new EnvironmentLoader();
 
   private final VaultInvoker vault;
-  private final List<String> secretsPath;
+  private final List<String> secretsPaths;
 
-  /**
-   * Create a new {@link VaultConfigSource}.
-   *  @param vault vault invoker.
-   * @param secretsPaths secret path-s.
-   */
   private VaultConfigSource(VaultInvoker vault, List<String> secretsPaths) {
     this.vault = vault;
-    this.secretsPath = secretsPaths;
+    this.secretsPaths = new ArrayList<>(secretsPaths);
   }
 
   @Override
   public Map<String, ConfigProperty> loadConfig() {
     Map<String, ConfigProperty> result = new HashMap<>();
-    for (String path : secretsPath) {
+    for (String path : secretsPaths) {
       try {
         LogicalResponse response = vault.invoke(vault -> vault.logical().read(path));
-        final Map<String, LoadedConfigProperty> pathProps = response.getData().entrySet().stream()
-            .map(LoadedConfigProperty::withNameAndValue)
-            .map(LoadedConfigProperty.Builder::build)
-            .collect(Collectors.toMap(LoadedConfigProperty::name, Function.identity()));
+        final Map<String, LoadedConfigProperty> pathProps =
+            response.getData().entrySet().stream()
+                .map(LoadedConfigProperty::withNameAndValue)
+                .map(LoadedConfigProperty.Builder::build)
+                .collect(Collectors.toMap(LoadedConfigProperty::name, Function.identity()));
         result.putAll(pathProps);
       } catch (Exception ex) {
-        LOGGER.warn("unable to load config properties from {}",path, ex);
+        LOGGER.warn("Unable to load config properties from {}", path, ex);
         throw new ConfigSourceNotAvailableException(ex);
       }
     }
     return result;
   }
 
-  /**
-   * This builder method is used internally for test purposes. please use it only for tests. Please
-   * note the following required environment variables are required.
-   *
-   * <ul>
-   *   <li><code>VAULT_SECRETS_PATH</code> is the path to use (defaults to <code>secret</code>)
-   *   <li><code>VAULT_TOKEN</code> is the {@link VaultConfig#token(String) token} to use
-   *   <li><code>VAULT_ADDR</code> is the {@link VaultConfig#address(String) address} of the vault
-   *       (API)
-   * </ul>
-   */
   public static Builder builder() {
     return new Builder();
   }
 
-  /**
-   * This builder method is used internally for test purposes. please use it only for tests
-   *
-   * @param environmentLoader an {@link EnvironmentLoader}
-   */
-  static Builder builder(EnvironmentLoader environmentLoader) {
-    final Builder builder = new Builder();
-    if (environmentLoader != null) {
-      builder.environmentLoader = environmentLoader;
-    }
-    return builder;
-  }
-
   public static final class Builder {
 
-    private Function<VaultInvoker.Builder, VaultInvoker.Builder> vault = Function.identity();
+    private Function<VaultInvoker.Builder, VaultInvoker.Builder> builderFunction = b -> b;
+
     private VaultInvoker invoker;
-    private EnvironmentLoader environmentLoader = VaultInvoker.Builder.ENVIRONMENT_LOADER;
-    private List<String> secretsPaths = new ArrayList<>();
+
+    private List<String> secretsPaths =
+        Optional.ofNullable(ENVIRONMENT_LOADER.loadVariable("VAULT_SECRETS_PATH"))
+            .or(() -> Optional.ofNullable(ENVIRONMENT_LOADER.loadVariable("VAULT_SECRETS_PATHS")))
+            .map(s -> s.split(":"))
+            .map(Arrays::asList)
+            .orElseGet(ArrayList::new);
 
     private Builder() {}
 
+    /**
+     * @deprecated will be removed in future releases without notice, use {@link
+     *     #addSecretsPath(String...)} or {@link #secretsPaths(Collection)}.
+     */
+    @Deprecated
     public Builder secretsPath(String secretsPath) {
-      this.secretsPaths.add(secretsPath);
+      this.secretsPaths.addAll(toSecretsPaths(Collections.singletonList(secretsPath)));
       return this;
+    }
+
+    public Builder addSecretsPath(String... secretsPath) {
+      this.secretsPaths.addAll(toSecretsPaths(Arrays.asList(secretsPath)));
+      return this;
+    }
+
+    public Builder secretsPaths(Collection<String> secretsPaths) {
+      this.secretsPaths = toSecretsPaths(secretsPaths);
+      return this;
+    }
+
+    private static List<String> toSecretsPaths(Collection<String> secretsPaths) {
+      return secretsPaths.stream()
+          .flatMap(s -> Arrays.stream(s.split(":")))
+          .distinct()
+          .collect(Collectors.toList());
     }
 
     public Builder invoker(VaultInvoker invoker) {
@@ -110,17 +112,17 @@ public class VaultConfigSource implements ConfigSource {
     }
 
     public Builder vault(UnaryOperator<VaultInvoker.Builder> config) {
-      this.vault = this.vault.andThen(config);
+      this.builderFunction = this.builderFunction.andThen(config);
       return this;
     }
 
     public Builder config(UnaryOperator<VaultConfig> vaultConfig) {
-      this.vault = this.vault.andThen(c -> c.options(vaultConfig));
+      this.builderFunction = this.builderFunction.andThen(c -> c.options(vaultConfig));
       return this;
     }
 
     public Builder tokenSupplier(VaultTokenSupplier supplier) {
-      this.vault = this.vault.andThen(c -> c.tokenSupplier(supplier));
+      this.builderFunction = this.builderFunction.andThen(c -> c.tokenSupplier(supplier));
       return this;
     }
 
@@ -130,17 +132,9 @@ public class VaultConfigSource implements ConfigSource {
      * @return instance of {@link VaultConfigSource}
      */
     public VaultConfigSource build() {
-      VaultInvoker vaultInvoker =
-          invoker != null
-              ? invoker
-              : vault.apply(new VaultInvoker.Builder(environmentLoader)).build();
-      if (secretsPaths.isEmpty()) {
-        String envSecretPath = Objects
-            .requireNonNull(environmentLoader.loadVariable(VAULT_SECRETS_PATH),
-                "Missing secretsPath");
-        secretsPaths = Arrays.asList(envSecretPath.split(":"));
-      }
-      return new VaultConfigSource(vaultInvoker, secretsPaths);
+      return new VaultConfigSource(
+          invoker != null ? invoker : builderFunction.apply(new VaultInvoker.Builder()).build(),
+          secretsPaths);
     }
   }
 }

--- a/config-vault/src/main/java/io/scalecube/config/vault/VaultTokenSupplier.java
+++ b/config-vault/src/main/java/io/scalecube/config/vault/VaultTokenSupplier.java
@@ -1,10 +1,9 @@
 package io.scalecube.config.vault;
 
-import com.bettercloud.vault.EnvironmentLoader;
 import com.bettercloud.vault.VaultConfig;
 
 @FunctionalInterface
 public interface VaultTokenSupplier {
 
-  String getToken(EnvironmentLoader environmentLoader, VaultConfig config);
+  String getToken(VaultConfig config);
 }

--- a/config-vault/src/test/java/io/scalecube/config/vault/VaultConfigSourceTest.java
+++ b/config-vault/src/test/java/io/scalecube/config/vault/VaultConfigSourceTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import com.bettercloud.vault.EnvironmentLoader;
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
 import io.scalecube.config.ConfigProperty;
@@ -21,7 +20,6 @@ import io.scalecube.config.ConfigRegistry;
 import io.scalecube.config.ConfigRegistrySettings;
 import io.scalecube.config.ConfigSourceNotAvailableException;
 import io.scalecube.config.StringConfigProperty;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -33,9 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 class VaultConfigSourceTest {
-
-  /** the environment variable name for vault secret path */
-  private static final String VAULT_SECRETS_PATH = "VAULT_SECRETS_PATH";
 
   // these 3 are actual values we would like to test with
   private static final String VAULT_SECRETS_PATH1 = "secret/application/tenant1";
@@ -55,20 +50,15 @@ class VaultConfigSourceTest {
     vaultInstance.putSecrets(VAULT_SECRETS_PATH3, "secret=password", "password=dbpassword");
   }
 
-  private EnvironmentLoader baseLoader =
-      new MockEnvironmentLoader()
-          .put("VAULT_TOKEN", vaultContainerExtension.vaultInstance().rootToken())
-          .put("VAULT_ADDR", vaultContainerExtension.vaultInstance().address());
-  private EnvironmentLoader loader1 =
-      new MockEnvironmentLoader(baseLoader).put(VAULT_SECRETS_PATH, VAULT_SECRETS_PATH1);
-  private EnvironmentLoader loader2 =
-      new MockEnvironmentLoader(baseLoader).put(VAULT_SECRETS_PATH, VAULT_SECRETS_PATH2);
-  private EnvironmentLoader loader3 =
-      new MockEnvironmentLoader(baseLoader).put(VAULT_SECRETS_PATH, VAULT_SECRETS_PATH3);
-
   @Test
   void testFirstTenant() {
-    VaultConfigSource vaultConfigSource = VaultConfigSource.builder(loader1).build();
+    VaultConfigSource vaultConfigSource =
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
+            .build();
+
     Map<String, ConfigProperty> loadConfig = vaultConfigSource.loadConfig();
     ConfigProperty actual = loadConfig.get("top_secret");
 
@@ -79,7 +69,13 @@ class VaultConfigSourceTest {
 
   @Test
   void testSecondTenant() {
-    VaultConfigSource vaultConfigSource = VaultConfigSource.builder(loader2).build();
+    VaultConfigSource vaultConfigSource =
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH2)
+            .build();
+
     Map<String, ConfigProperty> loadConfig = vaultConfigSource.loadConfig();
     ConfigProperty actual = loadConfig.get("top_secret");
 
@@ -90,32 +86,45 @@ class VaultConfigSourceTest {
 
   @Test
   void testMultiplePathsEnv() {
-    String commonPath = VAULT_SECRETS_PATH1 + ":" + VAULT_SECRETS_PATH2;
-    EnvironmentLoader multiLoader =
-        new MockEnvironmentLoader(baseLoader).put(VAULT_SECRETS_PATH, commonPath);
-    VaultConfigSource vaultConfigSource = VaultConfigSource.builder(multiLoader).build();
+    VaultConfigSource vaultConfigSource =
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1 + ":" + VAULT_SECRETS_PATH2)
+            .build();
     Map<String, ConfigProperty> loadConfig = vaultConfigSource.loadConfig();
 
     ConfigProperty commonSecret = loadConfig.get("top_secret");
     assertThat(commonSecret, notNullValue());
     assertThat(commonSecret.name(), equalTo("top_secret"));
-    assertThat("Second path should override the first one", commonSecret.valueAsString(""),
+    assertThat(
+        "Second path should override the first one",
+        commonSecret.valueAsString(""),
         equalTo("password2"));
 
     ConfigProperty fromFirstPath = loadConfig.get("only_first");
     assertThat(fromFirstPath.name(), equalTo("only_first"));
-    assertThat("Secret defined only in first path expected", fromFirstPath.valueAsString(""),
+    assertThat(
+        "Secret defined only in first path expected",
+        fromFirstPath.valueAsString(""),
         equalTo("pss1"));
 
     ConfigProperty fromSecondPath = loadConfig.get("only_second");
     assertThat(fromSecondPath.name(), equalTo("only_second"));
-    assertThat("Secret defined only in second path expected", fromSecondPath.valueAsString(""),
+    assertThat(
+        "Secret defined only in second path expected",
+        fromSecondPath.valueAsString(""),
         equalTo("pss2"));
   }
 
   @Test
   void testMissingProperty() {
-    VaultConfigSource vaultConfigSource = VaultConfigSource.builder(loader3).build();
+    VaultConfigSource vaultConfigSource =
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH3)
+            .build();
     Map<String, ConfigProperty> loadConfig = vaultConfigSource.loadConfig();
 
     assertThat(loadConfig.size(), not(0));
@@ -126,9 +135,12 @@ class VaultConfigSourceTest {
 
   @Test
   void testMissingTenant() {
-    EnvironmentLoader loader4 =
-        new MockEnvironmentLoader(baseLoader).put(VAULT_SECRETS_PATH, "secrets/unknown/path");
-    VaultConfigSource vaultConfigSource = VaultConfigSource.builder(loader4).build();
+    VaultConfigSource vaultConfigSource =
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath("secrets/unknown/path")
+            .build();
 
     assertThrows(ConfigSourceNotAvailableException.class, vaultConfigSource::loadConfig);
   }
@@ -136,11 +148,10 @@ class VaultConfigSourceTest {
   @Test
   void testInvalidAddress() {
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(
-                new MockEnvironmentLoader()
-                    .put("VAULT_ADDR", "http://invalid.host.local:8200")
-                    .put("VAULT_TOKEN", vaultContainerExtension.vaultInstance().rootToken())
-                    .put(VAULT_SECRETS_PATH, VAULT_SECRETS_PATH1))
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address("http://invalid.host.local:8200"))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
             .build();
 
     assertThrows(ConfigSourceNotAvailableException.class, vaultConfigSource::loadConfig);
@@ -149,10 +160,10 @@ class VaultConfigSourceTest {
   @Test
   void testInvalidToken() {
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(
-                new MockEnvironmentLoader(baseLoader)
-                    .put("VAULT_TOKEN", "zzzzzz")
-                    .put(VAULT_SECRETS_PATH, "secrets/unknown/path"))
+        VaultConfigSource.builder()
+            .config(c -> c.token("zzzzzz"))
+            .config(c -> c.address("http://invalid.host.local:8200"))
+            .addSecretsPath("secrets/unknown/path")
             .build();
 
     assertThrows(ConfigSourceNotAvailableException.class, vaultConfigSource::loadConfig);
@@ -172,7 +183,7 @@ class VaultConfigSourceTest {
                 "vault",
                 VaultConfigSource.builder()
                     .config(vaultConfig -> vaultConfig.address(address).token(rootToken))
-                    .secretsPath(VAULT_SECRETS_PATH1)
+                    .addSecretsPath(VAULT_SECRETS_PATH1)
                     .build())
             .jmxEnabled(false)
             .reloadIntervalSec(1)
@@ -206,7 +217,7 @@ class VaultConfigSourceTest {
                 "vault",
                 VaultConfigSource.builder()
                     .config(vaultConfig -> vaultConfig.address(address).token(rootToken))
-                    .secretsPath(VAULT_SECRETS_PATH1)
+                    .addSecretsPath(VAULT_SECRETS_PATH1)
                     .build())
             .jmxEnabled(false)
             .reloadIntervalSec(1)
@@ -236,12 +247,12 @@ class VaultConfigSourceTest {
       vault.seal().seal();
       assumeTrue(vault.seal().sealStatus().getSealed(), "vault seal status");
 
-      Map<String, String> clientEnv = new HashMap<>();
-      clientEnv.put("VAULT_TOKEN", "ROOT");
-      clientEnv.put("VAULT_ADDR", vaultInstance.address());
-      clientEnv.put(VAULT_SECRETS_PATH, VAULT_SECRETS_PATH1);
-
-      VaultConfigSource.builder(new MockEnvironmentLoader(clientEnv)).build().loadConfig();
+      VaultConfigSource.builder()
+          .config(c -> c.token("ROOT"))
+          .config(c -> c.address(vaultInstance.address()))
+          .addSecretsPath(VAULT_SECRETS_PATH1)
+          .build()
+          .loadConfig();
       fail("Negative test failed");
     } catch (ConfigSourceNotAvailableException expectedException) {
       assertThat(expectedException.getCause(), instanceOf(VaultException.class));
@@ -311,8 +322,11 @@ class VaultConfigSourceTest {
             .getAuthClientToken();
 
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(loader1)
-            .tokenSupplier((environmentLoader, config) -> token)
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
+            .tokenSupplier((config) -> token)
             .build();
 
     for (int i = 0; i < 10; i++) {
@@ -336,8 +350,11 @@ class VaultConfigSourceTest {
             .getAuthClientToken();
 
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(loader1)
-            .tokenSupplier((environmentLoader, config) -> token)
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
+            .tokenSupplier((config) -> token)
             .build();
 
     LongAdder times = new LongAdder();
@@ -371,8 +388,11 @@ class VaultConfigSourceTest {
             .getAuthClientToken();
 
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(loader1)
-            .tokenSupplier((environmentLoader, config) -> token)
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
+            .tokenSupplier((config) -> token)
             .build();
 
     LongAdder times = new LongAdder();
@@ -406,8 +426,11 @@ class VaultConfigSourceTest {
             .getAuthClientToken();
 
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(loader1)
-            .tokenSupplier((environmentLoader, config) -> token)
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
+            .tokenSupplier((config) -> token)
             .build();
 
     assertThrows(
@@ -429,9 +452,12 @@ class VaultConfigSourceTest {
   @Test
   void testTokenSupplierGeneratesNewRenewableTokenWithExplicitMaxTtl() throws Exception {
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(loader1)
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
             .tokenSupplier(
-                (environmentLoader, config) ->
+                (config) ->
                     vaultContainerExtension
                         .vaultInstance()
                         .createToken("-period=3s -renewable=true -explicit-max-ttl=6s")
@@ -459,8 +485,11 @@ class VaultConfigSourceTest {
             .getAuthClientToken();
 
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(loader1)
-            .tokenSupplier((environmentLoader, config) -> token)
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
+            .tokenSupplier((config) -> token)
             .build();
 
     assertThrows(
@@ -489,9 +518,12 @@ class VaultConfigSourceTest {
   void testTokenSupplierGeneratesNewRenewableTokenWhichWillBeRevoked() throws Exception {
     AtomicReference<String> tokenRef = new AtomicReference<>();
     VaultConfigSource vaultConfigSource =
-        VaultConfigSource.builder(loader1)
+        VaultConfigSource.builder()
+            .config(c -> c.token(vaultContainerExtension.vaultInstance().rootToken()))
+            .config(c -> c.address(vaultContainerExtension.vaultInstance().address()))
+            .addSecretsPath(VAULT_SECRETS_PATH1)
             .tokenSupplier(
-                (environmentLoader, config) -> {
+                (config) -> {
                   String token =
                       vaultContainerExtension
                           .vaultInstance()
@@ -517,37 +549,6 @@ class VaultConfigSourceTest {
             .vaultInstance()
             .execInContainer("vault token revoke " + tokenRef.get());
       }
-    }
-  }
-
-  private static class MockEnvironmentLoader extends EnvironmentLoader {
-    private final Map<String, String> env;
-
-    MockEnvironmentLoader() {
-      this(Collections.emptyMap());
-    }
-
-    MockEnvironmentLoader(EnvironmentLoader loader) {
-      this(((MockEnvironmentLoader) loader).env);
-    }
-
-    MockEnvironmentLoader(Map<String, String> base) {
-      this.env = new HashMap<>(base);
-    }
-
-    MockEnvironmentLoader put(String key, String value) {
-      env.put(key, value);
-      return this;
-    }
-
-    @Override
-    public String loadVariable(String name) {
-      return env.get(name);
-    }
-
-    @Override
-    public String toString() {
-      return "MockEnvironmentLoader{" + "env=" + env + '}';
     }
   }
 }


### PR DESCRIPTION
**Motivation**

Design of a component configuration via ENV variables and not via normal property setters -- is bad design. 

**Updates**

Made settings to come via config properties setter methods (initialization from ENV variables remained as default option). Get rid of `MockEnviro..Variabl...Loder`  in the test code.