### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/config-examples/pom.xml
+++ b/config-examples/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>scalecube-config-examples</artifactId>
 
   <properties>
-    <log4j.version>2.13.3</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832